### PR TITLE
add nscm signin, signout

### DIFF
--- a/bin/nscm.js
+++ b/bin/nscm.js
@@ -8,14 +8,20 @@ const tools = require('../lib/tools')
 
 // Commands
 const report = require('../commands/report')
+const signin = require('../commands/signin')
+const signout = require('../commands/signout')
 
 const commands = [
   'report',
   'whitelist',
   'config',
+  'signin',
+  'signout',
   'r',
   'w',
-  'c'
+  'c',
+  's',
+  'o'
 ]
 
 args
@@ -26,9 +32,13 @@ args
   .option('json', 'Formats the report in JSON', false)
   .option('dot', 'Formats the report in Graphiz dot', false)
   .option('svg', 'Formats the report in SVG', false)
+  .option('github', 'Sign in using GitHub SSO', false)
+  .option('google', 'Sign in using Google SSO', false)
   .command('report', 'Get a report of your packages', report, ['r'])
   .command('whitelist', 'Whitelist your packages', ['w'])
   .command('config', 'Configure nscm options', ['c'])
+  .command('signin', 'Sign in to nscm', signin, ['s'])
+  .command('signout', 'Sign out of nscm', signout, ['o'])
 
 const flags = args.parse(process.argv, {
   usageFilter: tools.usageFilter

--- a/commands/signin.js
+++ b/commands/signin.js
@@ -1,0 +1,138 @@
+const request = require('request')
+const crypto = require('crypto')
+const open = require('open')
+const rls = require('readline-sync')
+const path = require('path')
+const os = require('os')
+const url = require('url')
+const { updateConfig } = require('../lib/rc')
+const json = require('../lib/json')
+const config = require('../lib/config')
+
+const verifier = base64URLEncode(crypto.randomBytes(32))
+const challenge = base64URLEncode(sha256(verifier))
+
+const clientId = config.store.get('clientId')
+const authProxy = config.store.get('authProxy')
+const redirectUri = config.store.get('redirectUri')
+const authDomain = config.store.get('authDomain')
+
+const exchangeUri = `http://${authProxy}/api-proxy/v1/oauth/token`
+const audience = `https://${authDomain}/userinfo`
+const scope = 'email offline_access openid'
+const device = 'nscm'
+const responseType = 'code'
+const codeChallengeMethod = 'S256'
+
+function base64URLEncode (str) {
+  return str.toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+}
+
+function sha256 (buffer) {
+  return crypto.createHash('sha256').update(buffer).digest()
+}
+
+function exchangeAuthCodeForAccessToken (authorizationCode) {
+  const options = {
+    method: 'POST',
+    url: exchangeUri,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      "grant_type": "authorization_code",
+      "client_id": clientId,
+      "code_verifier": verifier,
+      "code": authorizationCode,
+      "redirect_uri": redirectUri
+    })
+  }
+
+  request(options, accessTokenReceived)
+}
+
+function stripProtocol (certifiedModulesUrl) {
+  const { hostname } = url.parse(certifiedModulesUrl)
+  return `//${hostname}/`
+}
+
+function accessTokenReceived (error, response, info) {
+  if (response.statusCode !== 200) {
+    console.error(info)
+  } else {
+    const parsedInfo = json(info)
+    if (parsedInfo) {
+      const commentChar = '#'
+      const { jwt, certifiedModulesUrl } = parsedInfo
+
+      if (jwt) {
+        const globalNpmrc = path.join(os.homedir(), '.npmrc')
+        const authTokenKey = stripProtocol(certifiedModulesUrl) + ':_authToken'
+        const onGlobalConfigParsed = (parsedConfig) => Object.assign(
+          parsedConfig, { [authTokenKey]: { value: jwt, comment: false } }
+        )
+        updateConfig(globalNpmrc, commentChar, onGlobalConfigParsed)
+        config.store.set('token', jwt)
+      } else {
+        console.error('signin failed: did not receive JWT')
+      }
+
+      if (certifiedModulesUrl) {
+        const localNpmrc = path.join(process.cwd(), '.npmrc')
+        const onLocalConfigParsed = (parsedConfig) => Object.assign(
+          parsedConfig, { registry: { value: certifiedModulesUrl, comment: false } }
+        )
+        updateConfig(localNpmrc, commentChar, onLocalConfigParsed)
+        config.store.set('registry', certifiedModulesUrl)
+      } else {
+        console.error('signin failed: did not receive certifiedModulesUrl')
+      }
+    } else {
+      console.error(`signin failed: error parsing response from ${authProxy}, info: ${info}`)
+    }
+  }
+}
+
+function ssoAuth (connection) {
+  const prompt = [
+    'a browser will launch and ask you to sign in.',
+    '',
+    'once you have the authorization code, please enter it here: '
+  ].join('\n')
+
+  const initialUrl = `https://${authDomain}/authorize?connection=${connection}&audience=${audience}&scope=${scope}&device=${device}&response_type=${responseType}&client_id=${clientId}&code_challenge=${challenge}&code_challenge_method=${codeChallengeMethod}&redirect_uri=${redirectUri}`
+
+  open(initialUrl, error => {
+    if (error) {
+      console.log(`open a browswer and navigate to: ${encodeURI(initialUrl)}`)
+    } else {
+      exchangeAuthCodeForAccessToken(rls.question(prompt))
+    }
+  })
+}
+
+function emailAuth () {
+  const email = rls.question('email: ')
+  const password = rls.question('password: ', { hideEchoBack: true, mask: '' })
+
+  const options = {
+    method: 'POST',
+    url: `https://${authProxy}/-/signin`,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  }
+
+  request(options, accessTokenReceived)
+}
+
+function signin (name, sub, options) {
+  if (options.github) {
+    ssoAuth('github')
+  } else if (options.google) {
+    ssoAuth('google-oauth2')
+  } else {
+    emailAuth()
+  }
+}
+module.exports = signin

--- a/commands/signout.js
+++ b/commands/signout.js
@@ -1,0 +1,22 @@
+const os = require('os')
+const path = require('path')
+const { updateConfig } = require('../lib/rc')
+const config = require('../lib/config')
+
+function signout () {
+  const isAuthTokenKey = (key) => key.includes('nodesource.io/:_authToken')
+  const commentChar = '#'
+
+  const globalNpmrc = path.join(os.homedir(), '.npmrc')
+  const onGlobalConfigParsed = (parsedConfig) => {
+    Object.keys(parsedConfig).forEach(key => {
+      if (isAuthTokenKey(key)) {
+        delete parsedConfig[key]
+      }
+    })
+    return parsedConfig
+  }
+  updateConfig(globalNpmrc, commentChar, onGlobalConfigParsed)
+  config.store.delete('token')
+}
+module.exports = signout

--- a/commands/whitelist.js
+++ b/commands/whitelist.js
@@ -86,7 +86,7 @@ function addWhitelist (opts, callback) {
       debug(res.statusCode, body)
 
       if (res.statusCode === 401) {
-        return next(new Error('authentication error, please run `npm login` or set a correct token'))
+        return next(new Error('authentication error, please run `nscm signin` or set a correct token'))
       }
 
       if (res.statusCode !== 200) {
@@ -159,9 +159,9 @@ function deletePackage (opts, callback) {
     debug(res.statusCode, body)
 
     if (res.statusCode === 401) {
-      if (isCallback) return callback(new Error('authentication error, please run `npm login` or set a correct token'))
+      if (isCallback) return callback(new Error('authentication error, please run `nscm signin` or set a correct token'))
 
-      log.panic('authentication error, please run `npm login` or set a correct token')
+      log.panic('authentication error, please run `nscm signin` or set a correct token')
       return
     }
 
@@ -213,9 +213,9 @@ function getWhitelist (opts, callback) {
     debug(res.statusCode, body)
 
     if (res.statusCode === 401) {
-      if (isCallback) return callback(new Error('authentication error, please run `npm login` or set a correct token'))
+      if (isCallback) return callback(new Error('authentication error, please run `nscm signin` or set a correct token'))
 
-      log.panic('authentication error, please run `npm login` or set a correct token')
+      log.panic('authentication error, please run `nscm signin` or set a correct token')
       return
     }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,12 +8,20 @@ const valid = [
   'registry',
   'token',
   'concurrency',
-  'publicRegistry'
+  'publicRegistry',
+  'clientId',
+  'authProxy',
+  'redirectUri',
+  'authDomain'
 ]
 
 const defaults = {
   concurrency: 15,
-  publicRegistry: 'https://registry.npmjs.org'
+  publicRegistry: 'https://registry.npmjs.org',
+  clientId: 'Ib0SpoV1Cx3hRaYEVJU523ZjFxmZYzfT',
+  authProxy: 'nodesource.registry.nodesource.io',
+  redirectUri: 'https://platform.nodesource.io/pkce',
+  authDomain: 'nodesource.auth0.com'
 }
 
 const store = new ConfigStore(pkg.name, defaults)

--- a/lib/json.js
+++ b/lib/json.js
@@ -1,0 +1,12 @@
+function json (str) {
+  str = String(str)
+
+  try {
+    return JSON.parse(str)
+  } catch (error) {
+    console.error(error, `json parse error on ${str.substring(0, 30)}`)
+  }
+
+  return undefined
+}
+module.exports = json

--- a/lib/rc.js
+++ b/lib/rc.js
@@ -1,0 +1,51 @@
+// serialize, deserialize .npmrc files
+const fs = require('fs')
+
+function stringify (parsedData, commentChar) {
+  return Object.keys(parsedData).map(key => {
+    const v = parsedData[key]
+    const finalKey = v.comment ? `${commentChar}${key}` : key
+    return `${finalKey}=${v.value}`
+  }).join('\n') + '\n'
+}
+exports.stringify = stringify
+
+function parse (rawData, commentChar) {
+  const parseKey = (key) => {
+    const comment = key.length > 0 && key[0] === commentChar
+    return comment ? { key: key.slice(1), comment } : { key, comment }
+  }
+
+  const parseLine = (result, line) => {
+    const parts = line.trim().split('=')
+    if (parts.length === 2) {
+      const { key, comment } = parseKey(parts[0].trim())
+      const value = parts[1].trim()
+      if (key) {
+        result[key] = { value, comment }
+      }
+    }
+    return result
+  }
+
+  return rawData.split('\n').reduce(parseLine, {})
+}
+exports.parse = parse
+
+function updateConfig (path, commentChar, onConfigParsed) {
+  overwriteFile(path, (npmrc) => stringify(
+    onConfigParsed(parse(npmrc, commentChar)), commentChar
+  ))
+}
+exports.updateConfig = updateConfig
+
+function overwriteFile (path, onInputRead) {
+  try {
+    fs.closeSync(fs.openSync(path, 'a+')) // if the file doesn't exist, create it
+    const encoding = 'utf-8'
+    fs.writeFileSync(path, onInputRead(fs.readFileSync(path, encoding)), encoding)
+  } catch (error) {
+    console.error(`error writing ${path}, error: ${error}`)
+  }
+}
+exports.overwriteFile = overwriteFile

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -68,7 +68,7 @@ function getOptions (opts, callback) {
     if (!token) {
       getJWT(opts.registry, function (err, t) {
         if (err) {
-          return callback(new Error('token option required, please use `npm login`'))
+          return callback(new Error('token option required, please use `nscm signin`'))
         }
 
         callback(null, Object.assign(opts, { token: t }))
@@ -148,7 +148,7 @@ function checkPackages (opts, callback) {
       debug(res.statusCode, body)
 
       if (res.statusCode === 401) {
-        return next(new Error('authentication error, please run `npm login` or set a correct token'))
+        return next(new Error('authentication error, please run `nscm signin` or set a correct token'))
       }
 
       // TODO: we need to check for correct statuses here

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "debug": "~2.6.1",
     "inquirer": "^3.0.1",
     "mkpath": "~1.0.0",
+    "open": "0.0.5",
+    "readline-sync": "^1.4.7",
     "request": "2.2.5",
     "rimraf": "~2.6.0",
     "semver": "~5.3.0",

--- a/tests/fixtures/npmrc
+++ b/tests/fixtures/npmrc
@@ -1,0 +1,8 @@
+init.author.name=Max Harris
+init.author.email=harris.max@gmail.com
+init.author.url=http://maxharris.org/
+email=npm@nodesource.com
+registry.npmjs.org/:_authToken=ab01234c-5678-901d-2345-e67f8g901hij
+progress=false
+#commentedkey=value
+//notacommentjustaprotocolfreeurl.com=chompinonkalelikeagiraffe

--- a/tests/rc-test.js
+++ b/tests/rc-test.js
@@ -1,0 +1,55 @@
+const test = require('tape')
+const { parse, stringify } = require('../lib/rc')
+const fs = require('fs')
+const path = require('path')
+
+const commentChar = '#'
+
+const rawData = fs.readFileSync(path.join(__dirname, 'fixtures', 'npmrc'), 'utf-8')
+const parsedData = {
+  'init.author.name': { value: 'Max Harris', comment: false },
+  'init.author.email': { value: 'harris.max@gmail.com', comment: false },
+  'init.author.url': { value: 'http://maxharris.org/', comment: false },
+  'email': { value: 'npm@nodesource.com', comment: false },
+  'registry.npmjs.org/:_authToken': { value: 'ab01234c-5678-901d-2345-e67f8g901hij', comment: false },
+  'progress': { value: 'false', comment: false },
+  'commentedkey': { value: 'value', comment: true },
+  '//notacommentjustaprotocolfreeurl.com': { value: 'chompinonkalelikeagiraffe', comment: false }
+}
+
+test('parse rc file contents', t => {
+  const actual = parse(rawData, commentChar)
+  t.deepEquals(actual, parsedData, 'parsed rc')
+  t.end()
+})
+
+test('stringify rc file contents', t => {
+  const actual = stringify(parsedData, commentChar)
+  t.equals(actual, rawData, 'stringified rc')
+  t.end()
+})
+
+test('parse rc file contents, with empty lines', t => {
+  const actual = parse(rawData + '\n\n\n', commentChar)
+  t.deepEquals(actual, parsedData, 'parsed rc')
+  t.end()
+})
+
+test('parse rc file contents, with empty key', t => {
+  const actual = parse(rawData + '\nfoo=', commentChar)
+  const expected = Object.assign({}, parsedData, { foo: { comment: false, value: '' } })
+  t.deepEquals(actual, expected, 'parsed rc')
+  t.end()
+})
+
+test('parse rc file contents, with empty value', t => {
+  const actual = parse(rawData + '\n=bar', commentChar)
+  t.deepEquals(actual, parsedData, 'parsed rc')
+  t.end()
+})
+
+test('parse rc file contents, with empty key and empty value', t => {
+  const actual = parse(rawData + '\n=', commentChar)
+  t.deepEquals(actual, parsedData, 'parsed rc')
+  t.end()
+})

--- a/tests/signin-test.js
+++ b/tests/signin-test.js
@@ -1,0 +1,120 @@
+const test = require('tape')
+const proxyquire = require('proxyquire')
+const fs = require('fs')
+const path = require('path')
+const url = require('url')
+const qs = require('querystring')
+const os = require('os')
+
+const npmrcFixture = fs.readFileSync(path.join(__dirname, 'fixtures', 'npmrc'), 'utf-8')
+const jwt = 'ab12cd34ef56gh78ij90ab12cd34ef56gh78.ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab12cd34ef56gh78ij.ab12cd34ef56gh78ij90ab12cd34ef56gh78ij90ab1'
+
+const globalNpmrc = (registryUrl, token) => [
+  'init.author.name=Max Harris',
+  'init.author.email=harris.max@gmail.com',
+  'init.author.url=http://maxharris.org/',
+  'email=npm@nodesource.com',
+  'registry.npmjs.org/:_authToken=ab01234c-5678-901d-2345-e67f8g901hij',
+  'progress=false',
+  '#commentedkey=value',
+  '//notacommentjustaprotocolfreeurl.com=chompinonkalelikeagiraffe',
+  `${registryUrl}/:_authToken=${token}`,
+  ''
+].join('\n')
+
+const localNpmrc = (registryUrl) => [
+  `registry=https:${registryUrl}`,
+  ''
+].join('\n')
+
+const isNpmrcGlobal = (fd) => fd === path.join(os.homedir(), '.npmrc')
+
+test('signin', t => {
+  const authCode = '12ab34cd56ef'
+  const registryUrl = '//ab12cd34ef56gh78ij90.registry.nodesource.io'
+
+  t.plan(12)
+  const signin = proxyquire('../commands/signin', {
+    open: (initialUrl, callback) => {
+      const parsedUrl = qs.parse(url.parse(initialUrl).query)
+      t.equals(parsedUrl.audience, 'https://nodesource.auth0.com/userinfo', 'initial url: audience')
+      t.equals(parsedUrl.scope, 'email offline_access openid', 'initial url: scope')
+      t.equals(parsedUrl.response_type, 'code', 'initial url: response type')
+      t.equals(parsedUrl.client_id, 'Ib0SpoV1Cx3hRaYEVJU523ZjFxmZYzfT', 'initial url: client id')
+      t.equals(parsedUrl.code_challenge.length, 43, 'initial url: code challenge')
+      t.equals(parsedUrl.code_challenge_method, 'S256', 'initial url: client id')
+      t.equals(parsedUrl.redirect_uri, 'https://platform.nodesource.io/pkce', 'initial url: redirect uri')
+      callback()
+    },
+    'readline-sync': {
+      question: (query, options) => {
+        t.pass('readline question')
+      }
+    },
+    fs: {
+      openSync: (path, mode, callback) => {
+        t.pass(`opening ${path}`)
+        return path
+      },
+      readFileSync: (fd) => {
+        t.pass(`reading ${fd}`)
+        if (isNpmrcGlobal(fd)) {
+          return npmrcFixture
+        } else {
+          return '\n'
+        }
+      },
+      writeFileSync: (fd, data, encoding) => {
+        t.equals(encoding, 'utf-8', 'write file encoding')
+
+        if (isNpmrcGlobal(fd)) {
+          t.equals(data, globalNpmrc(registryUrl, jwt), 'final global .npmrc data')
+        } else {
+          t.equals(data, localNpmrc(registryUrl), 'final local .npmrc data')
+        }
+      }
+    },
+    request: (options, accessTokenReceived) => {
+      accessTokenReceived(null, { statusCode: 200 }, JSON.stringify({
+        jwt, certifiedModulesUrl: `https:${registryUrl}`
+      }))
+    },
+    '../lib/rc': {
+      updateConfig: (configPath, commentChar, onConfigParsed) => {
+        t.equals(commentChar, '#', 'comment char')
+        onConfigParsed({})
+
+        const globalNpmrc = path.join(os.homedir(), '.npmrc')
+        const localNpmrc = path.join(process.cwd(), '.npmrc')
+
+        if (configPath === globalNpmrc) {
+          t.pass('wrote to global .npmrc')
+        } else if (configPath === localNpmrc) {
+          t.pass('wrote to local .npmrc')
+          t.end() // we always write the local one last
+        } else {
+          t.fail('unexpected configPath:', configPath)
+        }
+      }
+    },
+    '../lib/config': {
+      store: {
+        set: (key, value) => {},
+        get: (key) => {
+          switch (key) {
+            case 'clientId': return 'Ib0SpoV1Cx3hRaYEVJU523ZjFxmZYzfT'
+            case 'authProxy': return 'nodesource.registry.nodesource.io'
+            case 'redirectUri': return 'https://platform.nodesource.io/pkce'
+            case 'authDomain': return 'nodesource.auth0.com'
+            default: t.fail(`unexpected key: ${key}`)
+          }
+        }
+      }
+    }
+  })
+
+  signin(null, null, { github: true })
+
+  // TODO: signin(null, null, { google: true })
+  // TODO: signin(null, null, { })
+})


### PR DESCRIPTION
This PR adds support for authentication via SSO (single sign on). It adds `signin` and `signout` commands, which fetch, store and manage authentication and registry information from NCM.

NB: When `nscm signin` is invoked with the `--github` or `--google` options, it will attempt to bring up a web browser, which is required by the OAuth flow. (If this fails, it will print a URL to the terminal with directions on how to complete the authentication process.)