### PR TITLE
add login, logout aliases for signin, signout

### DIFF
--- a/bin/nscm.js
+++ b/bin/nscm.js
@@ -17,6 +17,8 @@ const commands = [
   'config',
   'signin',
   'signout',
+  'login',
+  'logout',
   'r',
   'w',
   'c',
@@ -37,8 +39,8 @@ args
   .command('report', 'Get a report of your packages', report, ['r'])
   .command('whitelist', 'Whitelist your packages', ['w'])
   .command('config', 'Configure nscm options', ['c'])
-  .command('signin', 'Sign in to nscm', signin, ['s'])
-  .command('signout', 'Sign out of nscm', signout, ['o'])
+  .command('signin', 'Sign in to nscm', signin, ['login', 's'])
+  .command('signout', 'Sign out of nscm', signout, ['logout', 'o'])
 
 const flags = args.parse(process.argv, {
   usageFilter: tools.usageFilter


### PR DESCRIPTION
This PR adds aliases for the `signin` and `signout` commands. Closes #8 