### PR TITLE
rc parser improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .npmrc
 .nyc_output
 node_modules/
+coverage/

--- a/commands/signin.js
+++ b/commands/signin.js
@@ -58,7 +58,10 @@ function stripProtocol (certifiedModulesUrl) {
 }
 
 function accessTokenReceived (error, response, info) {
-  if (error) { console.error(error) }
+  if (error) {
+    return console.error(`signin failed: unexpected error receiving access token: ${error}`)
+  }
+
   if (response.statusCode !== 200) {
     console.error(info)
   } else {

--- a/commands/signin.js
+++ b/commands/signin.js
@@ -41,11 +41,11 @@ function exchangeAuthCodeForAccessToken (authorizationCode) {
     url: exchangeUri,
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
-      'grant_type': 'authorization_code',
-      'client_id': clientId,
-      'code_verifier': verifier,
-      'code': authorizationCode,
-      'redirect_uri': redirectUri
+      grant_type: 'authorization_code',
+      client_id: clientId,
+      code_verifier: verifier,
+      code: authorizationCode,
+      redirect_uri: redirectUri
     })
   }
 

--- a/commands/signin.js
+++ b/commands/signin.js
@@ -41,11 +41,11 @@ function exchangeAuthCodeForAccessToken (authorizationCode) {
     url: exchangeUri,
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
-      "grant_type": "authorization_code",
-      "client_id": clientId,
-      "code_verifier": verifier,
-      "code": authorizationCode,
-      "redirect_uri": redirectUri
+      'grant_type': 'authorization_code',
+      'client_id': clientId,
+      'code_verifier': verifier,
+      'code': authorizationCode,
+      'redirect_uri': redirectUri
     })
   }
 
@@ -58,6 +58,7 @@ function stripProtocol (certifiedModulesUrl) {
 }
 
 function accessTokenReceived (error, response, info) {
+  if (error) { console.error(error) }
   if (response.statusCode !== 200) {
     console.error(info)
   } else {

--- a/lib/rc.js
+++ b/lib/rc.js
@@ -2,11 +2,11 @@
 const fs = require('fs')
 
 function stringify (parsedData, commentChar) {
-  return Object.keys(parsedData).map(key => {
-    const v = parsedData[key]
-    const finalKey = v.comment ? `${commentChar}${key}` : key
-    return `${finalKey}=${v.value}`
-  }).join('\n') + '\n'
+  return parsedData.map(line => {
+    const finalKey = line.comment ? `${commentChar}${line.key}` : line.key
+    const separator = finalKey && line.value ? '=' : ''
+    return finalKey + separator + line.value
+  }).join('\n')
 }
 exports.stringify = stringify
 
@@ -22,13 +22,16 @@ function parse (rawData, commentChar) {
       const { key, comment } = parseKey(parts[0].trim())
       const value = parts[1].trim()
       if (key) {
-        result[key] = { value, comment }
+        result.push({ key, value, comment })
       }
+    } else if (parts.length === 1) {
+      const { key, comment } = parseKey(parts[0].trim())
+      result.push({ key, value: '', comment})
     }
     return result
   }
 
-  return rawData.split('\n').reduce(parseLine, {})
+  return rawData.split('\n').reduce(parseLine, [])
 }
 exports.parse = parse
 

--- a/lib/rc.js
+++ b/lib/rc.js
@@ -26,7 +26,7 @@ function parse (rawData, commentChar) {
       }
     } else if (parts.length === 1) {
       const { key, comment } = parseKey(parts[0].trim())
-      result.push({ key, value: '', comment})
+      result.push({ key, value: '', comment })
     }
     return result
   }

--- a/lib/rc.js
+++ b/lib/rc.js
@@ -18,15 +18,19 @@ function parse (rawData, commentChar) {
 
   const parseLine = (result, line) => {
     const parts = line.trim().split('=')
-    if (parts.length === 2) {
+    if (parts.length === 2) { // we have a key and a value
       const { key, comment } = parseKey(parts[0].trim())
       const value = parts[1].trim()
       if (key) {
         result.push({ key, value, comment })
       }
-    } else if (parts.length === 1) {
-      const { key, comment } = parseKey(parts[0].trim())
-      result.push({ key, value: '', comment })
+    } else if (parts.length === 1) { // we just have a key
+      const content = parts[0].trim()
+      const { key, comment } = parseKey(content)
+
+      if (result.length > 0 || content !== '') { // if the first line is blank, ignore it
+        result.push({ key, value: '', comment })
+      }
     }
     return result
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "nyc tape tests/*-test.js | tap-spec",
     "coverage": "nyc report",
+    "detailed-coverage": "nyc report --reporter=lcov",
     "lint": "standard"
   },
   "repository": {

--- a/tests/fixtures/pmuellr
+++ b/tests/fixtures/pmuellr
@@ -1,0 +1,16 @@
+# must be mode 0600; eg `chmod 0600 .npmrc`
+
+cache=~/.npm-ncm
+# always-auth=true
+
+# registry=https://registry.npmjs.org/
+# registry=https://foo.registry.nodesource.io
+# registry=http://localhost:3002
+
+# pmuellr@nodesource.com
+# registry=https://xxxxxxxxxxxxxxxxxxxx.registry.nodesource.io/
+
+# pmuellr@apache.org
+# registry=https://yyyyyyyyyyyyyyyyyyyy.registry.nodesource.io/
+
+registry=https://yyyyyyyyyyyyyyyyyyyy.registry.nodesource.io/

--- a/tests/rc-test.js
+++ b/tests/rc-test.js
@@ -6,16 +6,17 @@ const path = require('path')
 const commentChar = '#'
 
 const rawData = fs.readFileSync(path.join(__dirname, 'fixtures', 'npmrc'), 'utf-8')
-const parsedData = {
-  'init.author.name': { value: 'Max Harris', comment: false },
-  'init.author.email': { value: 'harris.max@gmail.com', comment: false },
-  'init.author.url': { value: 'http://maxharris.org/', comment: false },
-  'email': { value: 'npm@nodesource.com', comment: false },
-  'registry.npmjs.org/:_authToken': { value: 'ab01234c-5678-901d-2345-e67f8g901hij', comment: false },
-  'progress': { value: 'false', comment: false },
-  'commentedkey': { value: 'value', comment: true },
-  '//notacommentjustaprotocolfreeurl.com': { value: 'chompinonkalelikeagiraffe', comment: false }
-}
+const parsedData = [
+  { key: 'init.author.name', value: 'Max Harris', comment: false },
+  { key: 'init.author.email', value: 'harris.max@gmail.com', comment: false },
+  { key: 'init.author.url', value: 'http://maxharris.org/', comment: false },
+  { key: 'email', value: 'npm@nodesource.com', comment: false },
+  { key: 'registry.npmjs.org/:_authToken', value: 'ab01234c-5678-901d-2345-e67f8g901hij', comment: false },
+  { key: 'progress', value: 'false', comment: false },
+  { key: 'commentedkey', value: 'value', comment: true },
+  { key: '//notacommentjustaprotocolfreeurl.com', value: 'chompinonkalelikeagiraffe', comment: false },
+  { key: '', value: '', comment: false }
+]
 
 test('parse rc file contents', t => {
   const actual = parse(rawData, commentChar)
@@ -29,15 +30,9 @@ test('stringify rc file contents', t => {
   t.end()
 })
 
-test('parse rc file contents, with empty lines', t => {
-  const actual = parse(rawData + '\n\n\n', commentChar)
-  t.deepEquals(actual, parsedData, 'parsed rc')
-  t.end()
-})
-
 test('parse rc file contents, with empty key', t => {
   const actual = parse(rawData + '\nfoo=', commentChar)
-  const expected = Object.assign({}, parsedData, { foo: { comment: false, value: '' } })
+  const expected = parsedData.concat({ key: 'foo', comment: false, value: '' })
   t.deepEquals(actual, expected, 'parsed rc')
   t.end()
 })
@@ -51,5 +46,38 @@ test('parse rc file contents, with empty value', t => {
 test('parse rc file contents, with empty key and empty value', t => {
   const actual = parse(rawData + '\n=', commentChar)
   t.deepEquals(actual, parsedData, 'parsed rc')
+  t.end()
+})
+
+const rawPmuellrData = fs.readFileSync(path.join(__dirname, 'fixtures', 'pmuellr'), 'utf-8')
+const parsedPmuellrData = [
+  { key: ' must be mode 0600; eg `chmod 0600 .npmrc`', value: '', comment: true },
+  { key: '', value: '', comment: false },
+  { key: 'cache', value: '~/.npm-ncm', comment: false },
+  { key: ' always-auth', value: 'true', comment: true },
+  { key: '', value: '', comment: false },
+  { key: ' registry', value: 'https://registry.npmjs.org/', comment: true },
+  { key: ' registry', value: 'https://foo.registry.nodesource.io', comment: true },
+  { key: ' registry', value: 'http://localhost:3002', comment: true },
+  { key: '', value: '', comment: false },
+  { key: ' pmuellr@nodesource.com', value: '', comment: true },
+  { key: ' registry', value: 'https://xxxxxxxxxxxxxxxxxxxx.registry.nodesource.io/', comment: true },
+  { key: '', value: '', comment: false },
+  { key: ' pmuellr@apache.org', value: '', comment: true },
+  { key: ' registry', value: 'https://yyyyyyyyyyyyyyyyyyyy.registry.nodesource.io/', comment: true },
+  { key: '', value: '', comment: false },
+  { key: 'registry', value: 'https://yyyyyyyyyyyyyyyyyyyy.registry.nodesource.io/', comment: false },
+  { key: '', value: '', comment: false }
+]
+
+test('parse pmuellr\'s rc file contents', t => {
+  const actual = parse(rawPmuellrData, commentChar)
+  t.deepEquals(actual, parsedPmuellrData, 'parsed pmuellr\'s rc')
+  t.end()
+})
+
+test('stringify pmuellr\'s parsed rc file', t => {
+  const actual = stringify(parsedPmuellrData, commentChar)
+  t.equals(actual, rawPmuellrData, 'stringified pmuellr\'s rc')
   t.end()
 })

--- a/tests/rc-test.js
+++ b/tests/rc-test.js
@@ -5,7 +5,9 @@ const path = require('path')
 
 const commentChar = '#'
 
-const rawData = fs.readFileSync(path.join(__dirname, 'fixtures', 'npmrc'), 'utf-8')
+const removeLastByte = (input) => input.substring(0, input.length - 1)
+
+const rawData = removeLastByte(fs.readFileSync(path.join(__dirname, 'fixtures', 'npmrc'), 'utf-8'))
 const parsedData = [
   { key: 'init.author.name', value: 'Max Harris', comment: false },
   { key: 'init.author.email', value: 'harris.max@gmail.com', comment: false },
@@ -14,9 +16,22 @@ const parsedData = [
   { key: 'registry.npmjs.org/:_authToken', value: 'ab01234c-5678-901d-2345-e67f8g901hij', comment: false },
   { key: 'progress', value: 'false', comment: false },
   { key: 'commentedkey', value: 'value', comment: true },
-  { key: '//notacommentjustaprotocolfreeurl.com', value: 'chompinonkalelikeagiraffe', comment: false },
-  { key: '', value: '', comment: false }
+  { key: '//notacommentjustaprotocolfreeurl.com', value: 'chompinonkalelikeagiraffe', comment: false }
 ]
+
+test('parse and stringify an empty file', t => {
+  const actual = parse('', commentChar)
+  t.deepEquals(actual, [], 'parsed empty rc')
+  t.equals(stringify(actual, commentChar), '', 'stringified empty rc')
+  t.end()
+})
+
+test('parse, alter and then stringify an empty file', t => {
+  const actual = parse('', commentChar)
+  const newLine = { key: 'new line here', value: '', comment: true }
+  t.equals(stringify(actual.concat(newLine), commentChar), '#new line here', 'stringified empty rc')
+  t.end()
+})
 
 test('parse rc file contents', t => {
   const actual = parse(rawData, commentChar)
@@ -49,7 +64,7 @@ test('parse rc file contents, with empty key and empty value', t => {
   t.end()
 })
 
-const rawPmuellrData = fs.readFileSync(path.join(__dirname, 'fixtures', 'pmuellr'), 'utf-8')
+const rawPmuellrData = removeLastByte(fs.readFileSync(path.join(__dirname, 'fixtures', 'pmuellr'), 'utf-8'))
 const parsedPmuellrData = [
   { key: ' must be mode 0600; eg `chmod 0600 .npmrc`', value: '', comment: true },
   { key: '', value: '', comment: false },
@@ -66,8 +81,7 @@ const parsedPmuellrData = [
   { key: ' pmuellr@apache.org', value: '', comment: true },
   { key: ' registry', value: 'https://yyyyyyyyyyyyyyyyyyyy.registry.nodesource.io/', comment: true },
   { key: '', value: '', comment: false },
-  { key: 'registry', value: 'https://yyyyyyyyyyyyyyyyyyyy.registry.nodesource.io/', comment: false },
-  { key: '', value: '', comment: false }
+  { key: 'registry', value: 'https://yyyyyyyyyyyyyyyyyyyy.registry.nodesource.io/', comment: false }
 ]
 
 test('parse pmuellr\'s rc file contents', t => {

--- a/tests/signin-test.js
+++ b/tests/signin-test.js
@@ -30,7 +30,6 @@ const localNpmrc = (registryUrl) => [
 const isNpmrcGlobal = (fd) => fd === path.join(os.homedir(), '.npmrc')
 
 test('signin', t => {
-  const authCode = '12ab34cd56ef'
   const registryUrl = '//ab12cd34ef56gh78ij90.registry.nodesource.io'
 
   t.plan(12)

--- a/tests/signin-test.js
+++ b/tests/signin-test.js
@@ -81,7 +81,7 @@ test('signin', t => {
     '../lib/rc': {
       updateConfig: (configPath, commentChar, onConfigParsed) => {
         t.equals(commentChar, '#', 'comment char')
-        onConfigParsed({})
+        onConfigParsed([])
 
         const globalNpmrc = path.join(os.homedir(), '.npmrc')
         const localNpmrc = path.join(process.cwd(), '.npmrc')


### PR DESCRIPTION
This PR adds support for comments and whitespace in the rc parser (used to parse `.npmrc` files). It also makes some minor changes to appease our linter. Finally, it adds a script (`detailed-coverage`), which provides a detailed coverage report to aid development.