### PR TITLE
switch to prompt-sync

### DIFF
--- a/commands/signin.js
+++ b/commands/signin.js
@@ -1,13 +1,15 @@
 const request = require('request')
 const crypto = require('crypto')
 const open = require('open')
-const rls = require('readline-sync')
+const ps = require('prompt-sync')
 const path = require('path')
 const os = require('os')
 const url = require('url')
 const { updateConfig } = require('../lib/rc')
 const json = require('../lib/json')
 const config = require('../lib/config')
+
+const question = ps({ sigint: true })
 
 const verifier = base64URLEncode(crypto.randomBytes(32))
 const challenge = base64URLEncode(sha256(verifier))
@@ -121,14 +123,14 @@ function ssoAuth (connection) {
     if (error) {
       console.log(`open a browswer and navigate to: ${encodeURI(initialUrl)}`)
     } else {
-      exchangeAuthCodeForAccessToken(rls.question(prompt))
+      exchangeAuthCodeForAccessToken(question(prompt))
     }
   })
 }
 
 function emailAuth () {
-  const email = rls.question('email: ')
-  const password = rls.question('password: ', { hideEchoBack: true, mask: '' })
+  const email = question('email: ')
+  const password = question('password: ', { echo: '*' })
 
   const options = {
     method: 'POST',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "inquirer": "^3.0.1",
     "mkpath": "~1.0.0",
     "open": "0.0.5",
-    "readline-sync": "^1.4.7",
+    "prompt-sync": "^4.1.5",
     "request": "2.2.5",
     "rimraf": "~2.6.0",
     "semver": "~5.3.0",

--- a/tests/signin-test.js
+++ b/tests/signin-test.js
@@ -45,10 +45,9 @@ test('signin', t => {
       t.equals(parsedUrl.redirect_uri, 'https://platform.nodesource.io/pkce', 'initial url: redirect uri')
       callback()
     },
-    'readline-sync': {
-      question: (query, options) => {
-        t.pass('readline question')
-      }
+    'prompt-sync': (config) => {
+      t.pass('readline question')
+      return (prompt, options) => {}
     },
     fs: {
       openSync: (path, mode, callback) => {


### PR DESCRIPTION
This PR replaces `readline-sync` with `prompt-sync` in order to resolve an issue caused by a bug in `readline-sync`. When merged, pressing `<ctrl>-c` will kill `nscm` as expected on macOS.

Bonus: '*' characters are now written to the screen when typing passwords in the username-password authentication flow.