### PR TITLE
Don't skip printing SSO token prompt when we can't open a browser.

### DIFF
--- a/commands/signin.js
+++ b/commands/signin.js
@@ -142,9 +142,9 @@ function ssoAuth (connection) {
   open(initialUrl, error => {
     if (error) {
       console.log(`open a browser and navigate to: ${encodeURI(initialUrl)}`)
-    } else {
-      rl.question(prompt, answer => exchangeAuthCodeForAccessToken(answer))
     }
+
+    rl.question(prompt, answer => exchangeAuthCodeForAccessToken(answer))
   })
 }
 


### PR DESCRIPTION
Don't skip printing SSO token prompt when we can't open a browser. Fixes #22.